### PR TITLE
Hash MySQL passwords

### DIFF
--- a/mysql/utils.go
+++ b/mysql/utils.go
@@ -1,0 +1,10 @@
+package mysql
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+func hashSum(contents interface{}) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(contents.(string))))
+}

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -11,16 +11,18 @@ description: |-
 The ``mysql_user`` resource creates and manages a user on a MySQL
 server.
 
-~> **Note:** All arguments including username and password will be stored in the raw state as plain-text.
+~> **Note:** The password for the user is provided in plain text, and is
+obscured by an unsalted hash in the state
 [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+Care is required when using this resource, to avoid disclosing the password.
 
 ## Example Usage
 
 ```hcl
 resource "mysql_user" "jdoe" {
-  user     = "jdoe"
-  host     = "example.com"
-  password = "password"
+  user               = "jdoe"
+  host               = "example.com"
+  plaintext_password = "password"
 }
 ```
 
@@ -32,8 +34,13 @@ The following arguments are supported:
 
 * `host` - (Optional) The source host of the user. Defaults to "localhost".
 
-* `password` - (Optional) The password of the user. The value of this
-  argument is plain-text so make sure to secure where this is defined.
+* `plaintext_password` - (Optional) The password for the user. This must be
+  provided in plain text, so the data source for it must be secured.
+  An _unsalted_ hash of the provided password is stored in state.
+
+* `password` - (Optional) Deprecated alias of `plaintext_password`, whose
+  value is *stored as plaintext in state*. Prefer to use `plaintext_password`
+  instead, which stores the password as an unsalted hash.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is a migration of @joshuaspence's work from hashicorp/terraform#13614.

----

Instead of storing MySQL passwords in plaintext, hash them first. This implementation is largely based on hashicorp/terraform#12128.