### PR TITLE
[WIP] Add support for authentication plugins

### DIFF
--- a/mysql/resource_user_test.go
+++ b/mysql/resource_user_test.go
@@ -37,6 +37,46 @@ func TestAccUser(t *testing.T) {
 	})
 }
 
+func TestAccUser_plugin(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccUserCheckDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccUserConfig_plugin,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserExists("mysql_user.test"),
+					testAccUserAuthenticationPlugin("mysql_user.test", "auth_socket", ""),
+					resource.TestCheckResourceAttr("mysql_user.test", "user", "jdoe"),
+					resource.TestCheckResourceAttr("mysql_user.test", "host", "localhost"),
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_plugin", "auth_socket"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccUserConfig_plugin2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserExists("mysql_user.test"),
+					testAccUserAuthenticationPlugin("mysql_user.test", "mysql_native_password", "*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19"),
+					resource.TestCheckResourceAttr("mysql_user.test", "user", "jdoe"),
+					resource.TestCheckResourceAttr("mysql_user.test", "host", "localhost"),
+					resource.TestCheckResourceAttr("mysql_user.test", "password", "password"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccUserConfig_plugin3,
+				Check: resource.ComposeTestCheckFunc(
+					testAccUserExists("mysql_user.test"),
+					testAccUserAuthenticationPlugin("mysql_user.test", "auth_socket", ""),
+					resource.TestCheckResourceAttr("mysql_user.test", "user", "jdoe"),
+					resource.TestCheckResourceAttr("mysql_user.test", "host", "localhost"),
+					resource.TestCheckResourceAttr("mysql_user.test", "auth_plugin", "auth_socket"),
+				),
+			},
+		},
+	})
+}
+
 func testAccUserExists(rn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
@@ -57,6 +97,43 @@ func testAccUserExists(rn string) resource.TestCheckFunc {
 		}
 		if len(rows) != 1 {
 			return fmt.Errorf("expected 1 row reading user but got %d", len(rows))
+		}
+
+		return nil
+	}
+}
+
+func testAccUserAuthenticationPlugin(rn string, authPlugin string, authString string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("User ID not set")
+		}
+
+		conn := testAccProvider.Meta().(*providerConfiguration).Conn
+		stmtSQL := fmt.Sprintf(
+			"SELECT plugin, authentication_string FROM mysql.user "+
+				"WHERE CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
+		log.Println("Executing statement:", stmtSQL)
+
+		rows, _, err := conn.Query(stmtSQL)
+		if err != nil {
+			return fmt.Errorf("Error reading user: %s", err)
+		}
+		if len(rows) != 1 {
+			return fmt.Errorf("Expected 1 row reading user but got %d rows", len(rows))
+		}
+
+		row := rows[0]
+		if authPlugin != row.Str(0) {
+			return fmt.Errorf("Expected plugin %s but got %s", authPlugin, row.Str(0))
+		}
+		if authString != row.Str(1) {
+			return fmt.Errorf("Expected authentication_string %s but got %s", authString, row.Str(1))
 		}
 
 		return nil
@@ -97,5 +174,29 @@ resource "mysql_user" "test" {
         user = "jdoe"
         host = "example.com"
         password = "password2"
+}
+`
+
+const testAccUserConfig_plugin = `
+resource "mysql_user" "test" {
+    user        = "jdoe"
+    host        = "localhost"
+    auth_plugin = "auth_socket"
+}
+`
+
+const testAccUserConfig_plugin2 = `
+resource "mysql_user" "test" {
+    user     = "jdoe"
+    host     = "localhost"
+    password = "password"
+}
+`
+
+const testAccUserConfig_plugin3 = `
+resource "mysql_user" "test" {
+    user        = "jdoe"
+    host        = "localhost"
+    auth_plugin = "auth_socket"
 }
 `


### PR DESCRIPTION
This pull request adds support for [authentication via plugins](https://dev.mysql.com/doc/refman/5.7/en/authentication-plugins.html). This is necessary in order to support the provisioning of user accounts for use with [IAM Database Authentication for MySQL and Amazon Aurora](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html).

I'm marking this as a WIP because I'll admit that I'm not super familiar with the intracasies of `CREATE USER` and `ALTER USER` SQL statements.