### PR TITLE
Fix `ReadDatabase` when default collation set

### DIFF
--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -106,7 +106,6 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 		// the charset, so if we don't have a collation we need to go
 		// hunt for the default.
 		stmtSQL := "SHOW COLLATION WHERE `Charset` = ? AND `Default` = 'Yes'"
-		var defaultCollation string
 		var empty interface{}
 		err := db.QueryRow(stmtSQL, defaultCharset).Scan(&defaultCollation, &empty, &empty, &empty, &empty, &empty)
 		if err != nil {
@@ -115,7 +114,6 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 			}
 			return fmt.Errorf("Error getting default charset: %s, %s", err, defaultCharset)
 		}
-		return err
 	}
 
 	d.Set("default_character_set", defaultCharset)

--- a/mysql/resource_database_test.go
+++ b/mysql/resource_database_test.go
@@ -12,23 +12,28 @@ import (
 )
 
 func TestAccDatabase(t *testing.T) {
-	var dbName string
+	dbName := "terraform_acceptance_test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccDatabaseCheckDestroy(dbName),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDatabaseConfig_basic,
-				Check: testAccDatabaseCheck(
-					"mysql_database.test", &dbName,
+				Config: testAccDatabaseConfig_basic(dbName),
+				Check: testAccDatabaseCheck_basic(
+					"mysql_database.test", dbName,
 				),
 			},
 		},
 	})
 }
 
-func testAccDatabaseCheck(rn string, name *string) resource.TestCheckFunc {
+func testAccDatabaseCheck_basic(rn string, name string) resource.TestCheckFunc {
+	return testAccDatabaseCheck_full(rn, name, "utf8", "utf8_bin")
+}
+
+func testAccDatabaseCheck_full(rn string, name string, charset string, collation string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[rn]
 		if !ok {
@@ -40,7 +45,7 @@ func testAccDatabaseCheck(rn string, name *string) resource.TestCheckFunc {
 		}
 
 		db := testAccProvider.Meta().(*providerConfiguration).DB
-		rows, err := db.Query("SHOW CREATE DATABASE terraform_acceptance_test")
+		rows, err := db.Query(fmt.Sprintf("SHOW CREATE DATABASE %s", name))
 		if err != nil {
 			return fmt.Errorf("error reading database: %s", err)
 		}
@@ -53,18 +58,16 @@ func testAccDatabaseCheck(rn string, name *string) resource.TestCheckFunc {
 			return fmt.Errorf("error scanning create statement: %s", err)
 		}
 
-		if strings.Index(createSQL, "CHARACTER SET utf8") == -1 {
-			return fmt.Errorf("database default charset isn't utf8")
+		if strings.Index(createSQL, fmt.Sprintf("CHARACTER SET %s", charset)) == -1 {
+			return fmt.Errorf("database default charset isn't %s", charset)
 		}
-		if strings.Index(createSQL, "COLLATE utf8_bin") == -1 {
-			return fmt.Errorf("database default collation isn't utf8_bin")
+		if strings.Index(createSQL, fmt.Sprintf("COLLATE %s", collation)) == -1 {
+			return fmt.Errorf("database default collation isn't %s", collation)
 		}
 
 		if rows.Next() {
 			return fmt.Errorf("expected 1 row reading database, but got more")
 		}
-
-		*name = rs.Primary.ID
 
 		return nil
 	}
@@ -74,8 +77,8 @@ func testAccDatabaseCheckDestroy(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		db := testAccProvider.Meta().(*providerConfiguration).DB
 
-		var name, createSQL string
-		err := db.QueryRow("SHOW CREATE DATABASE terraform_acceptance_test").Scan(&name, &createSQL)
+		var _name, createSQL string
+		err := db.QueryRow(fmt.Sprintf("SHOW CREATE DATABASE %s", name)).Scan(&_name, &createSQL)
 		if err == nil {
 			return fmt.Errorf("database still exists after destroy")
 		}
@@ -90,10 +93,15 @@ func testAccDatabaseCheckDestroy(name string) resource.TestCheckFunc {
 	}
 }
 
-const testAccDatabaseConfig_basic = `
-resource "mysql_database" "test" {
-    name = "terraform_acceptance_test"
-    default_character_set = "utf8"
-    default_collation = "utf8_bin"
+func testAccDatabaseConfig_basic(name string) string {
+	return testAccDatabaseConfig_full(name, "utf8", "utf8_bin")
 }
-`
+
+func testAccDatabaseConfig_full(name string, charset string, collation string) string {
+	return fmt.Sprintf(`
+resource "mysql_database" "test" {
+    name = "%s"
+    default_character_set = "%s"
+    default_collation = "%s"
+}`, name, charset, collation)
+}


### PR DESCRIPTION
I discovered an issue with the `ReadDatabase` function when the collation is the default for the charset. While it makes the query to retrieve the default collation, it does not set the "default_character_set" and "default_collation" values on the ResourceData object.

# Steps to Reproduce

1. Load the following resource
    ```
    resource "mysql_database" "test" {
        name = "test"
        default_character_set = "utf8"
        default_collation = "utf8_bin"
    }
    ```
2. Modify the database default collation
    ```
    ALTER DATABASE test COLLATE utf8_general_ci
    ```
3. Attempt to apply the first resource again
    ```
    resource "mysql_database" "test" {
        name = "test"
        default_character_set = "utf8"
        default_collation = "utf8_bin"
    }
    ```

# Expected Behavior

Terraform should detect the modified collation and attempt to update the database

# Actual Behavior

Terraform does not recognize the modification to collation and acts as though the database is still "utf8_bin"