### PR TITLE
new way to use sql connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ # wait for a few seconds to let MySQL stand up, check the logs with: docker lo
 $ export MYSQL_USERNAME=root
 $ export MYSQL_ENDPOINT=localhost:3306
 $ export MYSQL_PASSWORD=my-secret-pw
-$ mysql -h localhost -u root -p -e "INSTALL PLUGIN mysql_no_login SONAME 'mysql_no_login.so';"
+$ mysql -h 127.0.0.1 -u root -p -e "INSTALL PLUGIN mysql_no_login SONAME 'mysql_no_login.so';"
 $ make testacc
 $ docker rm -f some-mysql
 ```

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -13,8 +13,7 @@ import (
 )
 
 type providerConfiguration struct {
-	DB            *sql.DB
-	ServerVersion *version.Version
+	Data string
 }
 
 func Provider() terraform.ResourceProvider {
@@ -81,16 +80,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	// operations.
 
 	dataSourceName := fmt.Sprintf("%s:%s@%s(%s)/", username, password, proto, endpoint)
-	db, err := sql.Open("mysql", dataSourceName)
-
-	ver, err := serverVersion(db)
-	if err != nil {
-		return nil, err
-	}
 
 	return &providerConfiguration{
-		DB:            db,
-		ServerVersion: ver,
+		Data: dataSourceName,
 	}, nil
 }
 


### PR DESCRIPTION
For default the mysql provider use providerConfigure function like [ConfigureFunc](https://github.com/hashicorp/terraform/blob/master/helper/schema/provider.go#L49). This function create a sql connection for default, but this is a problem if the database is not available when we executes the terraform plan/apply (for example using services like Google Cloud Platform or AWS, when the plan contains the databases to creates and the new mysql users to apply, in the same file).

So I fixed this situation changed the way to use the sql connection, creating a unique connection for any resource.

I think this it not the best solution for the issue, but this approach allow use the mysql provider with others like GCP provider.