### PR TITLE
Support mysql_grant table

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -37,6 +37,13 @@ func resourceGrant() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"table": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "*",
+			},
+
 			"privileges": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
@@ -67,9 +74,10 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 	privileges = strings.Join(privilegesList, ",")
 
-	stmtSQL := fmt.Sprintf("GRANT %s on %s.* TO '%s'@'%s'",
+	stmtSQL := fmt.Sprintf("GRANT %s on %s.%s TO '%s'@'%s'",
 		privileges,
 		d.Get("database").(string),
+		d.Get("table").(string),
 		d.Get("user").(string),
 		d.Get("host").(string))
 
@@ -110,8 +118,9 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	db := meta.(*providerConfiguration).DB
 
-	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.* FROM '%s'@'%s'",
+	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.%s FROM '%s'@'%s'",
 		d.Get("database").(string),
+		d.Get("table").(string),
 		d.Get("user").(string),
 		d.Get("host").(string))
 
@@ -121,8 +130,9 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	stmtSQL = fmt.Sprintf("REVOKE ALL ON %s.* FROM '%s'@'%s'",
+	stmtSQL = fmt.Sprintf("REVOKE ALL ON %s.%s FROM '%s'@'%s'",
 		d.Get("database").(string),
+		d.Get("table").(string),
 		d.Get("user").(string),
 		d.Get("host").(string))
 

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -24,6 +24,7 @@ func TestAccGrant(t *testing.T) {
 					resource.TestCheckResourceAttr("mysql_grant.test", "user", "jdoe"),
 					resource.TestCheckResourceAttr("mysql_grant.test", "host", "example.com"),
 					resource.TestCheckResourceAttr("mysql_grant.test", "database", "foo"),
+					resource.TestCheckResourceAttr("mysql_grant.test", "table", "*"),
 				),
 			},
 		},


### PR DESCRIPTION
The current mysql_grant will always give permissions to all tables.
But I want to grant privileges on certain tables in the database.

So add a table argument so you can specify the table.
If table argument is not set, it is the same `mydb.*` as before, so backwards compatibility is maintained.