### PR TITLE
Switch to lazy connections to MySQL and add TLS configuration support to the provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+terraform-provider-mysql
 bin/
 modules-dev/
 /pkg/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ BUG FIXES:
 
 * Lazily connect to MySQL servers. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
 * Add retries to MySQL server connection logic. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
-* Provider now has a `tls` option that configures TSL for server connections. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
 * Migrated to Go modules for dependencies and `vendor/` management.
 
 IMPROVEMENTS:
 
+* Provider now has a `tls` option that configures TSL for server connections. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
 * `r/mysql_user`: Added the `tls_option` attribute, which allows to restrict the MySQL users to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
 * `r/mysql_grant`: Added the `tls_option` attribute, which allows to restrict the MySQL grant to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
+* `r/mysql_grant`: Added a `table` argument that allows `GRANT` statements to be scoped to a single table.
 
 ## 1.1.0 (March 28, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,22 @@
-## 1.1.1 (Unreleased)
+## 1.5.0 (Unreleased)
+
+BUG FIXES:
+
+* Lazily connect to MySQL servers. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
+* Add retries to MySQL server connection logic. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
+* Provider now has a `tls` option that configures TSL for server connections. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
+* Migrated to Go modules for dependencies and `vendor/` management.
 
 IMPROVEMENTS:
 
-* `resource/user`: Added the `tls_option` attribute, which allows to restrict
-  the MySQL users to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
-
-* `resource/gant`: Added the `tls_option` attribute, which allows to restrict
-  the MySQL grant to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
+* `r/mysql_user`: Added the `tls_option` attribute, which allows to restrict the MySQL users to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
+* `r/mysql_grant`: Added the `tls_option` attribute, which allows to restrict the MySQL grant to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
 
 ## 1.1.0 (March 28, 2018)
 
 IMPROVEMENTS:
 
-* `resource/user`: Added the `auth_plugin` attribute, which allows for the use
-  of authentication plugins when creating MySQL users. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/26))
+* `resource/user`: Added the `auth_plugin` attribute, which allows for the use of authentication plugins when creating MySQL users. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/26))
 
 ## 1.0.1 (January 03, 2018)
 
@@ -25,9 +28,9 @@ BUG FIXES:
 
 UPGRADE NOTES:
 
-* This provider is now using a different underlying library to access MySQL (See [[#16](https://github.com/terraform-providers/terraform-provider-mysql/issues/16)]). This should be a drop-in replacement for all of the functionality exposed by this provider, but just in case it is suggested to test cautiously after upgrading (review plans before applying, etc) in case of any edge-cases in interactions with specific versions of MySQL.
+* This provider is now using a different underlying library to access MySQL (See [#16](https://github.com/terraform-providers/terraform-provider-mysql/issues/16)). This should be a drop-in replacement for all of the functionality exposed by this provider, but just in case it is suggested to test cautiously after upgrading (review plans before applying, etc) in case of any edge-cases in interactions with specific versions of MySQL.
 
-ENHANCEMENTS:
+IMPROVEMENTS:
 
 * `mysql_user` now has a `plaintext_password` argument which stores its value in state as an _unsalted_ hash. This deprecates `password`, which stores its value in the state in cleartext. Since the hash is unsalted, some care is still warranted to secure the state, and a strong password should be used to reduce the chance of a successful brute-force attack on the hash. ([#9](https://github.com/terraform-providers/terraform-provider-mysql/issues/9))
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-$PROVIDER_NAME`
+Clone repository to: `$GOPATH/src/github.com/terraform-providers/terraform-provider-mysql`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-$PROVIDER_NAME
+$ git clone git@github.com:terraform-providers/terraform-provider-mysql
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-$PROVIDER_NAME
+$ cd $GOPATH/src/github.com/terraform-providers/terraform-provider-mysql
 $ make build
 ```
 
@@ -44,7 +44,7 @@ To compile the provider, run `make build`. This will build the provider and put 
 ```sh
 $ make bin
 ...
-$ $GOPATH/bin/terraform-provider-$PROVIDER_NAME
+$ $GOPATH/bin/terraform-provider-mysql
 ...
 ```
 

--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -45,12 +45,15 @@ func resourceDatabase() *schema.Resource {
 }
 
 func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*providerConfiguration).DB
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	stmtSQL := databaseConfigSQL("CREATE", d)
 	log.Println("Executing statement:", stmtSQL)
 
-	_, err := db.Exec(stmtSQL)
+	_, err = db.Exec(stmtSQL)
 	if err != nil {
 		return err
 	}
@@ -61,12 +64,15 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*providerConfiguration).DB
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	stmtSQL := databaseConfigSQL("ALTER", d)
 	log.Println("Executing statement:", stmtSQL)
 
-	_, err := db.Exec(stmtSQL)
+	_, err = db.Exec(stmtSQL)
 	if err != nil {
 		return err
 	}
@@ -75,7 +81,10 @@ func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*providerConfiguration).DB
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	// This is kinda flimsy-feeling, since it depends on the formatting
 	// of the SHOW CREATE DATABASE output... but this data doesn't seem
@@ -87,7 +96,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 
 	log.Println("Executing query:", stmtSQL)
 	var createSQL, _database string
-	err := db.QueryRow(stmtSQL).Scan(&_database, &createSQL)
+	err = db.QueryRow(stmtSQL).Scan(&_database, &createSQL)
 	if err != nil {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 			if mysqlErr.Number == unknownDatabaseErrCode {
@@ -123,13 +132,16 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteDatabase(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*providerConfiguration).DB
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	name := d.Id()
 	stmtSQL := "DROP DATABASE " + quoteIdentifier(name)
 	log.Println("Executing statement:", stmtSQL)
 
-	_, err := db.Exec(stmtSQL)
+	_, err = db.Exec(stmtSQL)
 	if err == nil {
 		d.SetId("")
 	}

--- a/mysql/resource_database_test.go
+++ b/mysql/resource_database_test.go
@@ -52,7 +52,11 @@ func TestAccDatabase_collationChange(t *testing.T) {
 			},
 			resource.TestStep{
 				PreConfig: func() {
-					db := testAccProvider.Meta().(*providerConfiguration).DB
+					db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+					if err != nil {
+						return err
+					}
+
 					db.Query(fmt.Sprintf("ALTER DATABASE %s CHARACTER SET %s COLLATE %s", dbName, charset2, collation2))
 				},
 				Config: testAccDatabaseConfig_full(dbName, charset1, collation1),
@@ -81,7 +85,11 @@ func testAccDatabaseCheck_full(rn string, name string, charset string, collation
 			return fmt.Errorf("database id not set")
 		}
 
-		db := testAccProvider.Meta().(*providerConfiguration).DB
+		db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+		if err != nil {
+			return err
+		}
+
 		rows, err := db.Query(fmt.Sprintf("SHOW CREATE DATABASE %s", name))
 		if err != nil {
 			return fmt.Errorf("error reading database: %s", err)
@@ -112,7 +120,10 @@ func testAccDatabaseCheck_full(rn string, name string, charset string, collation
 
 func testAccDatabaseCheckDestroy(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		db := testAccProvider.Meta().(*providerConfiguration).DB
+		db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+		if err != nil {
+			return err
+		}
 
 		var _name, createSQL string
 		err := db.QueryRow(fmt.Sprintf("SHOW CREATE DATABASE %s", name)).Scan(&_name, &createSQL)

--- a/mysql/resource_database_test.go
+++ b/mysql/resource_database_test.go
@@ -54,7 +54,7 @@ func TestAccDatabase_collationChange(t *testing.T) {
 				PreConfig: func() {
 					db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
 					if err != nil {
-						return err
+						return
 					}
 
 					db.Query(fmt.Sprintf("ALTER DATABASE %s CHARACTER SET %s COLLATE %s", dbName, charset2, collation2))
@@ -126,7 +126,7 @@ func testAccDatabaseCheckDestroy(name string) resource.TestCheckFunc {
 		}
 
 		var _name, createSQL string
-		err := db.QueryRow(fmt.Sprintf("SHOW CREATE DATABASE %s", name)).Scan(&_name, &createSQL)
+		err = db.QueryRow(fmt.Sprintf("SHOW CREATE DATABASE %s", name)).Scan(&_name, &createSQL)
 		if err == nil {
 			return fmt.Errorf("database still exists after destroy")
 		}

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -56,7 +56,10 @@ func resourceGrant() *schema.Resource {
 }
 
 func CreateGrant(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*providerConfiguration).DB
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	// create a comma-delimited string of privileges
 	var privileges string
@@ -78,7 +81,7 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Println("Executing statement:", stmtSQL)
-	_, err := db.Exec(stmtSQL)
+	_, err = db.Exec(stmtSQL)
 	if err != nil {
 		return err
 	}
@@ -90,7 +93,10 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadGrant(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*providerConfiguration).DB
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	stmtSQL := fmt.Sprintf("SHOW GRANTS FOR '%s'@'%s'",
 		d.Get("user").(string),
@@ -108,7 +114,10 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
-	db := meta.(*providerConfiguration).DB
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.* FROM '%s'@'%s'",
 		d.Get("database").(string),
@@ -116,7 +125,7 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 		d.Get("host").(string))
 
 	log.Println("Executing statement:", stmtSQL)
-	_, err := db.Query(stmtSQL)
+	_, err = db.Query(stmtSQL)
 	if err != nil {
 		return err
 	}

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -46,7 +46,11 @@ func testAccPrivilegeExists(rn string, privilege string) resource.TestCheckFunc 
 		user := userhost[0]
 		host := userhost[1]
 
-		db := testAccProvider.Meta().(*providerConfiguration).DB
+		db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+		if err != nil {
+			return err
+		}
+
 		stmtSQL := fmt.Sprintf("SHOW GRANTS for '%s'@'%s'", user, host)
 		log.Println("Executing statement:", stmtSQL)
 		rows, err := db.Query(stmtSQL)
@@ -78,7 +82,10 @@ func testAccPrivilegeExists(rn string, privilege string) resource.TestCheckFunc 
 }
 
 func testAccGrantCheckDestroy(s *terraform.State) error {
-	db := testAccProvider.Meta().(*providerConfiguration).DB
+	db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mysql_grant" {

--- a/mysql/resource_user_test.go
+++ b/mysql/resource_user_test.go
@@ -96,7 +96,11 @@ func testAccUserExists(rn string) resource.TestCheckFunc {
 			return fmt.Errorf("user id not set")
 		}
 
-		db := testAccProvider.Meta().(*providerConfiguration).DB
+		db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+		if err != nil {
+			return err
+		}
+
 		stmtSQL := fmt.Sprintf("SELECT count(*) from mysql.user where CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
 		log.Println("Executing statement:", stmtSQL)
 		var count int
@@ -123,7 +127,11 @@ func testAccUserAuthExists(rn string) resource.TestCheckFunc {
 			return fmt.Errorf("user id not set")
 		}
 
-		db := testAccProvider.Meta().(*providerConfiguration).DB
+		db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+		if err != nil {
+			return err
+		}
+
 		stmtSQL := fmt.Sprintf("SELECT count(*) from mysql.user where CONCAT(user, '@', host) = '%s' and plugin = 'mysql_no_login'", rs.Primary.ID)
 		log.Println("Executing statement:", stmtSQL)
 		var count int
@@ -140,7 +148,10 @@ func testAccUserAuthExists(rn string) resource.TestCheckFunc {
 }
 
 func testAccUserCheckDestroy(s *terraform.State) error {
-	db := testAccProvider.Meta().(*providerConfiguration).DB
+	db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "mysql_user" {

--- a/mysql/resource_user_test.go
+++ b/mysql/resource_user_test.go
@@ -104,7 +104,7 @@ func testAccUserExists(rn string) resource.TestCheckFunc {
 		stmtSQL := fmt.Sprintf("SELECT count(*) from mysql.user where CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
 		log.Println("Executing statement:", stmtSQL)
 		var count int
-		err := db.QueryRow(stmtSQL).Scan(&count)
+		err = db.QueryRow(stmtSQL).Scan(&count)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return fmt.Errorf("expected 1 row reading user but got no rows")
@@ -135,7 +135,7 @@ func testAccUserAuthExists(rn string) resource.TestCheckFunc {
 		stmtSQL := fmt.Sprintf("SELECT count(*) from mysql.user where CONCAT(user, '@', host) = '%s' and plugin = 'mysql_no_login'", rs.Primary.ID)
 		log.Println("Executing statement:", stmtSQL)
 		var count int
-		err := db.QueryRow(stmtSQL).Scan(&count)
+		err = db.QueryRow(stmtSQL).Scan(&count)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				return fmt.Errorf("expected 1 row reading user but got no rows")

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -71,3 +71,4 @@ The following arguments are supported:
 * `endpoint` - (Required) The address of the MySQL server to use. Most often a "hostname:port" pair, but may also be an absolute path to a Unix socket when the host OS is Unix-compatible.
 * `username` - (Required) Username to use to authenticate with the server.
 * `password` - (Optional) Password for the given user, if that user has a password.
+* `tls` - (Optional) The TLS configuration. One of `false`, `true`, or `skip-verify`. Defaults to `false`.

--- a/website/docs/r/grant.html.markdown
+++ b/website/docs/r/grant.html.markdown
@@ -33,24 +33,11 @@ resource "mysql_grant" "jdoe" {
 The following arguments are supported:
 
 * `user` - (Required) The name of the user.
-
 * `host` - (Optional) The source host of the user. Defaults to "localhost".
-
-* `database` - (Required) The database to grant privileges on. At this time,
-  privileges are given to all tables on the database (`mydb.*`).
-
-* `privileges` - (Required) A list of privileges to grant to the user. Refer
-  to a list of privileges (such as
-  [here](https://dev.mysql.com/doc/refman/5.5/en/grant.html)) for applicable
-  privileges.
-
-* `tls_option` - (Optional) An TLS-Option for the GRANT-Statement
-  The Value is suffixed to REQUIRE. F.e. the value 'SSL' will
-  gernate an SQL like this: `GRANT ..... REQUIRE SSL`
-  See https://dev.mysql.com/doc/refman/5.7/en/grant.html
-
-* `grant` - (Optional) Whether to also give the user privileges to grant
-  the same privileges to other users.
+* `database` - (Required) The database to grant privileges on. At this time, privileges are given to all tables on the database (`mydb.*`).
+* `privileges` - (Required) A list of privileges to grant to the user. Refer to a list of privileges (such as [here](https://dev.mysql.com/doc/refman/5.5/en/grant.html)) for applicable privileges.
+* `tls_option` - (Optional) An TLS-Option for the `GRANT` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `GRANT ... REQUIRE SSL` statement. See the [MYSQL `GRANT` documentation](https://dev.mysql.com/doc/refman/5.7/en/grant.html) for more. Ignored if MySQL version is under 5.7.0.
+* `grant` - (Optional) Whether to also give the user privileges to grant the same privileges to other users.
 
 ## Attributes Reference
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -41,29 +41,11 @@ resource "mysql_user" "nologin" {
 The following arguments are supported:
 
 * `user` - (Required) The name of the user.
-
 * `host` - (Optional) The source host of the user. Defaults to "localhost".
-
-* `plaintext_password` - (Optional) The password for the user. This must be
-  provided in plain text, so the data source for it must be secured.
-  An _unsalted_ hash of the provided password is stored in state. Conflicts
-  with `auth_plugin`.
-
-* `password` - (Optional) Deprecated alias of `plaintext_password`, whose
-  value is *stored as plaintext in state*. Prefer to use `plaintext_password`
-  instead, which stores the password as an unsalted hash. Conflicts with
-  `auth_plugin`.
-
-* `auth_plugin` - (Optional) Use an [authentication plugin][ref-auth-plugins]
-  to authenticate the user instead of using password authentication.
-  Description of the fields allowed in the block below. Conflicts with
-  `password` and `plaintext_password`.
-
-* `tls_option` - (Optional) An TLS-Option for the CREATE USER-Statement or ALTER USER
-  The Value is suffixed to REQUIRE. F.e. the value 'SSL' will
-  gernate an SQL like this: `CREATE USER ..... REQUIRE SSL`
-  See https://dev.mysql.com/doc/refman/5.7/en/create-user.html
-  For MySql-Server-Versions less than 5.7 this options will be ignored.
+* `plaintext_password` - (Optional) The password for the user. This must be provided in plain text, so the data source for it must be secured. An _unsalted_ hash of the provided password is stored in state. Conflicts with `auth_plugin`.
+* `password` - (Optional) Deprecated alias of `plaintext_password`, whose value is *stored as plaintext in state*. Prefer to use `plaintext_password` instead, which stores the password as an unsalted hash. Conflicts with `auth_plugin`.
+* `auth_plugin` - (Optional) Use an [authentication plugin][ref-auth-plugins] to authenticate the user instead of using password authentication.  Description of the fields allowed in the block below. Conflicts with `password` and `plaintext_password`.  
+* `tls_option` - (Optional) An TLS-Option for the `CREATE USER` or `ALTER USER` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `CREATE USER ... REQUIRE SSL` statement. See the [MYSQL `CREATE USER` documentation](https://dev.mysql.com/doc/refman/5.7/en/create-user.html) for more. Ignored if MySQL version is under 5.7.0.
 
 [ref-auth-plugins]: https://dev.mysql.com/doc/refman/5.7/en/authentication-plugins.html
 
@@ -90,3 +72,7 @@ The following attributes are exported:
 * `password` - The password of the user.
 * `id` - The id of the user created, composed as "username@host".
 * `host` - The host where the user was created.
+
+## Attributes Reference
+
+No further attributes are exported.


### PR DESCRIPTION
## What does this PR change?

* The provider and all resources now connect to MySQL lazily. Closes #37. Fixes #2. Fixes #3. Fixes #1.
* Add retry logic when connecting to the MySQL server. This gives time for both the server and the MySQL service to boot up without breaking the provisioning process.
* Adds TLS support to the provider. Fixes #7. Closes #17.
* Use `@@GLOBAL.innodb_version` instead of `VERSION()` to detect server version. Fixes #18.
* Adds the ability to import `mysql_database` resources using `terraform import`. Fixes #29.

## Example HCL

Used a modified version of @andricicezar's HCL from [his comment](https://github.com/terraform-providers/terraform-provider-mysql/issues/2#issuecomment-365314762) on #2. 

```hcl
provider "docker" {
  host = "unix:///var/run/docker.sock"
}

resource "docker_image" "database" {
  name = "mysql:5"
}

resource "docker_container" "database" {
  name  = "database"
  image = "${docker_image.database.latest}"
  env = [ "MYSQL_ROOT_PASSWORD=example" ]
  network_mode = "bridge"

  ports {
    internal = "3306"
    external = "32769"
  }
}

provider "mysql" {
  endpoint = "localhost:32769"
  username = "root"
  password = "example"
}

resource "mysql_database" "example" {
  name = "example"
}

output "ip_address" {
  value = "${docker_container.database.ip_address}"
}
```

## Test output

```
MYSQL_ENDPOINT="localhost" MYSQL_USERNAME="root" MYSQL_PASSWORD="" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?   	github.com/terraform-providers/terraform-provider-mysql	[no test files]
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDatabase
--- PASS: TestAccDatabase (0.05s)
=== RUN   TestAccDatabase_collationChange
--- PASS: TestAccDatabase_collationChange (0.06s)
=== RUN   TestAccGrant
--- PASS: TestAccGrant (0.06s)
=== RUN   TestAccUser_basic
--- PASS: TestAccUser_basic (0.05s)
=== RUN   TestAccUser_auth
--- PASS: TestAccUser_auth (0.03s)
=== RUN   TestAccUser_deprecated
--- PASS: TestAccUser_deprecated (0.05s)
PASS
ok  	github.com/terraform-providers/terraform-provider-mysql/mysql	0.409s
```