### PR TITLE
Introduce a mysql_role resource for creating MySQL roles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,43 @@
 dist: trusty
+
 sudo: required
+
 language: go
-services:
-- docker
-- mysql
+
 go:
-- 1.10.x
+  - 1.10.x
+
+env:
+  - DB=mysql:5.6 DB_EXTRA=''
+  - DB=mysql:5.7 DB_EXTRA=''
+  - DB=mysql:8.0 DB_EXTRA='mysqld --default-authentication-plugin=mysql_native_password'
+
+services:
+  - docker
 
 script:
-- test -d /home/travis/gopath/src/github.com/terraform-providers || mv $(dirname $PWD) /home/travis/gopath/src/github.com/terraform-providers
-- make test
-- make vet
-- make website-test
-- export MYSQL_USERNAME=root
-- export MYSQL_ENDPOINT=localhost:3306
-- export MYSQL_PASSWORD=
-- mysql -u root -e "INSTALL PLUGIN mysql_no_login SONAME 'mysql_no_login.so';"
-- make testacc
+  - test -d /home/travis/gopath/src/github.com/terraform-providers || mv $(dirname $PWD) /home/travis/gopath/src/github.com/terraform-providers
+  - make test
+  - make vet
+  - make website-test
+  - sudo service mysql stop
+  - export MYSQL_HOST=127.0.0.1
+  - export MYSQL_PORT=3306
+  - export MYSQL_USERNAME=root
+  - export MYSQL_ENDPOINT="${MYSQL_HOST}:${MYSQL_PORT}"
+  - export MYSQL_PASSWORD=''
+  - docker pull $DB
+  - docker run -d -p ${MYSQL_HOST}:${MYSQL_PORT}:${MYSQL_PORT} -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_ROOT_PASSWORD='' $DB $DB_EXTRA
+  - docker ps -a
+  - |
+    while ! mysql -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USERNAME} -e 'SELECT 1'; do
+      echo 'Waiting for MySQL...'
+      sleep 1;
+    done;
+  - mysql -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USERNAME} -e "INSTALL PLUGIN mysql_no_login SONAME 'mysql_no_login.so';"
+  - make testacc
 
 matrix:
   fast_finish: true
   allow_failures:
-  - go: tip
+    - go: tip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ BUG FIXES:
 
 * Lazily connect to MySQL servers. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
 * Add retries to MySQL server connection logic. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
-* Migrated to Go modules for dependencies and `vendor/` management.
+* Migrated to Go modules for dependencies and `vendor/` management. ([#44](https://github.com/terraform-providers/terraform-provider-mysql/issues/44))
 
 IMPROVEMENTS:
 
-* Provider now has a `tls` option that configures TSL for server connections. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
-* `r/mysql_user`: Added the `tls_option` attribute, which allows to restrict the MySQL users to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
-* `r/mysql_grant`: Added the `tls_option` attribute, which allows to restrict the MySQL grant to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
+* Provider now supports MySQL 8. ([#48](https://github.com/terraform-providers/terraform-provider-mysql/issues/48))
+* Provider now has a `tls` argument that configures TSL for server connections. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
+* `r/mysql_user`: Added the `tls_option` argument, which allows to restrict the MySQL users to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
+* `r/mysql_grant`: Added the `tls_option` argument, which allows to restrict the MySQL grant to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
 * `r/mysql_grant`: Added a `table` argument that allows `GRANT` statements to be scoped to a single table. ([#39](https://github.com/terraform-providers/terraform-provider-mysql/issues/30))
 * `r/mysql_user_password`: Manages a PGP encrypted randomly assigned password for the given MySQL user. ([#50](https://github.com/terraform-providers/terraform-provider-mysql/issues/50))
+* `r/mysql_role`: New resource for managing MySQL roles. ([#48](https://github.com/terraform-providers/terraform-provider-mysql/issues/48))
 
 ## 1.1.0 (March 28, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
-* Provider now supports MySQL 8. ([#48](https://github.com/terraform-providers/terraform-provider-mysql/issues/48))
+* Provider now supports MySQL 8. ([#53](https://github.com/terraform-providers/terraform-provider-mysql/issues/53))
+* Acceptance tests now ran against MySQL 5.6, 5.7, and 8.0.
 * Provider now has a `tls` argument that configures TSL for server connections. ([#43](https://github.com/terraform-providers/terraform-provider-mysql/issues/43))
 * `r/mysql_user`: Added the `tls_option` argument, which allows to restrict the MySQL users to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
 * `r/mysql_grant`: Added the `tls_option` argument, which allows to restrict the MySQL grant to a specific MySQL-TLS-Encryption. ([#26](https://github.com/terraform-providers/terraform-provider-mysql/issues/40))
 * `r/mysql_grant`: Added a `table` argument that allows `GRANT` statements to be scoped to a single table. ([#39](https://github.com/terraform-providers/terraform-provider-mysql/issues/30))
+* `r/mysql_grant`: Added a `role` argument that allows `GRANT` assign privileges to roles. ([#53](https://github.com/terraform-providers/terraform-provider-mysql/issues/53))
+* `r/mysql_grant`: Added a `roles` argument that allows `GRANT` assign roles to a user. ([#53](https://github.com/terraform-providers/terraform-provider-mysql/issues/53))
 * `r/mysql_user_password`: Manages a PGP encrypted randomly assigned password for the given MySQL user. ([#50](https://github.com/terraform-providers/terraform-provider-mysql/issues/50))
 * `r/mysql_role`: New resource for managing MySQL roles. ([#48](https://github.com/terraform-providers/terraform-provider-mysql/issues/48))
 

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -66,6 +66,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"mysql_database":      resourceDatabase(),
 			"mysql_grant":         resourceGrant(),
+			"mysql_role":          resourceRole(),
 			"mysql_user":          resourceUser(),
 			"mysql_user_password": resourceUserPassword(),
 		},

--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
-
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -118,12 +118,27 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 		// hunt for the default.
 		stmtSQL := "SHOW COLLATION WHERE `Charset` = ? AND `Default` = 'Yes'"
 		var empty interface{}
-		err := db.QueryRow(stmtSQL, defaultCharset).Scan(&defaultCollation, &empty, &empty, &empty, &empty, &empty)
+
+		requiredVersion, _ := version.NewVersion("8.0.0")
+		currentVersion, err := serverVersion(db)
 		if err != nil {
-			if err == sql.ErrNoRows {
+			return err
+		}
+
+		// MySQL 8 returns more data in a row.
+		var res error
+		if currentVersion.GreaterThan(requiredVersion) {
+			res = db.QueryRow(stmtSQL, defaultCharset).Scan(&defaultCollation, &empty, &empty, &empty, &empty, &empty, &empty)
+		} else {
+			res = db.QueryRow(stmtSQL, defaultCharset).Scan(&defaultCollation, &empty, &empty, &empty, &empty, &empty)
+		}
+
+		if res != nil {
+			if res == sql.ErrNoRows {
 				return fmt.Errorf("Charset %s has no default collation", defaultCharset)
 			}
-			return fmt.Errorf("Error getting default charset: %s, %s", err, defaultCharset)
+
+			return fmt.Errorf("Error getting default charset: %s, %s", res, defaultCharset)
 		}
 	}
 

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -19,16 +20,25 @@ func resourceGrant() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"user": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"role"},
+			},
+
+			"role": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"user", "host"},
 			},
 
 			"host": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "localhost",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Default:       "localhost",
+				ConflictsWith: []string{"role"},
 			},
 
 			"database": &schema.Schema{
@@ -46,10 +56,19 @@ func resourceGrant() *schema.Resource {
 
 			"privileges": &schema.Schema{
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
+			},
+
+			"roles": &schema.Schema{
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"privileges"},
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
 			},
 
 			"grant": &schema.Schema{
@@ -69,6 +88,15 @@ func resourceGrant() *schema.Resource {
 	}
 }
 
+func flattenList(list []interface{}) string {
+	var result []string
+	for _, v := range list {
+		result = append(result, v.(string))
+	}
+
+	return strings.Join(result, ", ")
+}
+
 func formatDatabaseName(database string) string {
 	if strings.Compare(database, "*") != 0 && !strings.HasSuffix(database, "`") {
 		return fmt.Sprintf("`%s`", database)
@@ -83,25 +111,54 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// create a comma-delimited string of privileges
-	var privileges string
-	var privilegesList []string
-	vL := d.Get("privileges").(*schema.Set).List()
-	for _, v := range vL {
-		privilegesList = append(privilegesList, v.(string))
+	currentVersion, err := serverVersion(db)
+	if err != nil {
+		return err
 	}
-	privileges = strings.Join(privilegesList, ",")
+
+	requiredVersion, _ := version.NewVersion("8.0.0")
+	hasRoles := currentVersion.GreaterThan(requiredVersion)
+
+	var privilegesOrRoles string
+	if attr, ok := d.GetOk("privileges"); ok {
+		privilegesOrRoles = flattenList(attr.(*schema.Set).List())
+	} else if attr, ok := d.GetOk("roles"); ok {
+		if !hasRoles {
+			return fmt.Errorf("Roles are only supported on MySQL 8 and above")
+		}
+		privilegesOrRoles = flattenList(attr.(*schema.Set).List())
+	} else {
+		return fmt.Errorf("One of privileges or roles is required")
+	}
+
+	user := d.Get("user").(string)
+	host := d.Get("host").(string)
+	role := d.Get("role").(string)
+
+	var userOrRole string
+	if len(user) > 0 && len(host) > 0 {
+		userOrRole = fmt.Sprintf("'%s'@'%s'", user, host)
+	} else if len(role) > 0 {
+		if !hasRoles {
+			return fmt.Errorf("Roles are only supported on MySQL 8 and above")
+		}
+		userOrRole = fmt.Sprintf("'%s'", role)
+	} else {
+		return fmt.Errorf("user with host or a role is required")
+	}
 
 	database := formatDatabaseName(d.Get("database").(string))
 
-	stmtSQL := fmt.Sprintf("GRANT %s on %s.%s TO '%s'@'%s'",
-		privileges,
+	stmtSQL := fmt.Sprintf("GRANT %s on %s.%s TO %s",
+		privilegesOrRoles,
 		database,
 		d.Get("table").(string),
-		d.Get("user").(string),
-		d.Get("host").(string))
+		userOrRole)
 
-	stmtSQL += fmt.Sprintf(" REQUIRE %s", d.Get("tls_option").(string))
+	// MySQL 8+ doesn't allow REQUIRE on a GRANT statement.
+	if !hasRoles {
+		stmtSQL += fmt.Sprintf(" REQUIRE %s", d.Get("tls_option").(string))
+	}
 
 	if d.Get("grant").(bool) {
 		stmtSQL += " WITH GRANT OPTION"
@@ -110,11 +167,11 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 	log.Println("Executing statement:", stmtSQL)
 	_, err = db.Exec(stmtSQL)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error runnin SQL (%s): %s", stmtSQL, err)
 	}
 
-	user := fmt.Sprintf("%s@%s:%s", d.Get("user").(string), d.Get("host").(string), d.Get("database").(string))
-	d.SetId(user)
+	id := fmt.Sprintf("%s@%s:%s", d.Get("user").(string), d.Get("host").(string), d.Get("database").(string))
+	d.SetId(id)
 
 	return ReadGrant(d, meta)
 }

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"strings"
@@ -43,7 +44,7 @@ func resourceGrant() *schema.Resource {
 
 			"database": &schema.Schema{
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 
@@ -88,10 +89,10 @@ func resourceGrant() *schema.Resource {
 	}
 }
 
-func flattenList(list []interface{}) string {
+func flattenList(list []interface{}, template string) string {
 	var result []string
 	for _, v := range list {
-		result = append(result, v.(string))
+		result = append(result, fmt.Sprintf(template, v.(string)))
 	}
 
 	return strings.Join(result, ", ")
@@ -105,28 +106,59 @@ func formatDatabaseName(database string) string {
 	return database
 }
 
+func userOrRole(user string, host string, role string, hasRoles bool) (string, bool, error) {
+	if len(user) > 0 && len(host) > 0 {
+		return fmt.Sprintf("'%s'@'%s'", user, host), false, nil
+	} else if len(role) > 0 {
+		if !hasRoles {
+			return "", false, fmt.Errorf("Roles are only supported on MySQL 8 and above")
+		}
+
+		return fmt.Sprintf("'%s'", role), true, nil
+	} else {
+		return "", false, fmt.Errorf("user with host or a role is required")
+	}
+}
+
+func supportsRoles(db *sql.DB) (bool, error) {
+	currentVersion, err := serverVersion(db)
+	if err != nil {
+		return false, err
+	}
+
+	requiredVersion, _ := version.NewVersion("8.0.0")
+	hasRoles := currentVersion.GreaterThan(requiredVersion)
+	return hasRoles, nil
+}
+
 func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
 	if err != nil {
 		return err
 	}
 
-	currentVersion, err := serverVersion(db)
+	hasRoles, err := supportsRoles(db)
 	if err != nil {
 		return err
 	}
 
-	requiredVersion, _ := version.NewVersion("8.0.0")
-	hasRoles := currentVersion.GreaterThan(requiredVersion)
+	var (
+		privilegesOrRoles string
+		grantOn           string
+	)
 
-	var privilegesOrRoles string
+	hasPrivs := false
+	rolesGranted := 0
 	if attr, ok := d.GetOk("privileges"); ok {
-		privilegesOrRoles = flattenList(attr.(*schema.Set).List())
+		privilegesOrRoles = flattenList(attr.(*schema.Set).List(), "%s")
+		hasPrivs = true
 	} else if attr, ok := d.GetOk("roles"); ok {
 		if !hasRoles {
 			return fmt.Errorf("Roles are only supported on MySQL 8 and above")
 		}
-		privilegesOrRoles = flattenList(attr.(*schema.Set).List())
+		listOfRoles := attr.(*schema.Set).List()
+		rolesGranted = len(listOfRoles)
+		privilegesOrRoles = flattenList(listOfRoles, "'%s'")
 	} else {
 		return fmt.Errorf("One of privileges or roles is required")
 	}
@@ -134,24 +166,16 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 	user := d.Get("user").(string)
 	host := d.Get("host").(string)
 	role := d.Get("role").(string)
+
+	userOrRole, isRole, err := userOrRole(user, host, role, hasRoles)
+	if err != nil {
+		return err
+	}
+
 	database := formatDatabaseName(d.Get("database").(string))
 
-	var (
-		grantOn    string
-		userOrRole string
-	)
-
-	if len(user) > 0 && len(host) > 0 {
-		userOrRole = fmt.Sprintf("'%s'@'%s'", user, host)
-		grantOn = fmt.Sprintf(" on %s.%s", database, d.Get("table").(string))
-	} else if len(role) > 0 {
-		if !hasRoles {
-			return fmt.Errorf("Roles are only supported on MySQL 8 and above")
-		}
-		userOrRole = fmt.Sprintf("'%s'", role)
-		grantOn = ""
-	} else {
-		return fmt.Errorf("user with host or a role is required")
+	if (!isRole || hasPrivs) && rolesGranted == 0 {
+		grantOn = fmt.Sprintf(" ON %s.%s", database, d.Get("table").(string))
 	}
 
 	stmtSQL := fmt.Sprintf("GRANT %s%s TO %s",
@@ -164,17 +188,21 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 		stmtSQL += fmt.Sprintf(" REQUIRE %s", d.Get("tls_option").(string))
 	}
 
-	if d.Get("grant").(bool) {
+	if !hasRoles && !isRole && d.Get("grant").(bool) {
 		stmtSQL += " WITH GRANT OPTION"
 	}
 
 	log.Println("Executing statement:", stmtSQL)
 	_, err = db.Exec(stmtSQL)
 	if err != nil {
-		return fmt.Errorf("Error runnin SQL (%s): %s", stmtSQL, err)
+		return fmt.Errorf("Error running SQL (%s): %s", stmtSQL, err)
 	}
 
-	id := fmt.Sprintf("%s@%s:%s", d.Get("user").(string), d.Get("host").(string), d.Get("database").(string))
+	id := fmt.Sprintf("%s@%s:%s", user, host, database)
+	if isRole {
+		id = fmt.Sprintf("%s:%s", role, database)
+	}
+
 	d.SetId(id)
 
 	return ReadGrant(d, meta)
@@ -186,14 +214,27 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	stmtSQL := fmt.Sprintf("SHOW GRANTS FOR '%s'@'%s'",
-		d.Get("user").(string),
-		d.Get("host").(string))
-
-	log.Println("Executing statement:", stmtSQL)
-
-	_, err = db.Exec(stmtSQL)
+	hasRoles, err := supportsRoles(db)
 	if err != nil {
+		return err
+	}
+
+	userOrRole, _, err := userOrRole(
+		d.Get("user").(string),
+		d.Get("host").(string),
+		d.Get("role").(string),
+		hasRoles)
+	if err != nil {
+		return err
+	}
+
+	sql := fmt.Sprintf("SHOW GRANTS FOR %s", userOrRole)
+
+	log.Println("[DEBUG] SQL:", sql)
+
+	_, err = db.Exec(sql)
+	if err != nil {
+		log.Printf("[WARN] GRANT not found for %s - removing from state", userOrRole)
 		d.SetId("")
 	}
 
@@ -208,28 +249,46 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 
 	database := formatDatabaseName(d.Get("database").(string))
 
-	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.%s FROM '%s'@'%s'",
-		database,
-		d.Get("table").(string),
-		d.Get("user").(string),
-		d.Get("host").(string))
-
-	log.Println("Executing statement:", stmtSQL)
-	_, err = db.Exec(stmtSQL)
+	hasRoles, err := supportsRoles(db)
 	if err != nil {
 		return err
 	}
 
-	stmtSQL = fmt.Sprintf("REVOKE ALL ON %s.%s FROM '%s'@'%s'",
-		database,
-		d.Get("table").(string),
+	userOrRole, isRole, err := userOrRole(
 		d.Get("user").(string),
-		d.Get("host").(string))
-
-	log.Println("Executing statement:", stmtSQL)
-	_, err = db.Exec(stmtSQL)
+		d.Get("host").(string),
+		d.Get("role").(string),
+		hasRoles)
 	if err != nil {
 		return err
+	}
+
+	roles := d.Get("roles").(*schema.Set)
+
+	var sql string
+	if !isRole && len(roles.List()) == 0 {
+		sql = fmt.Sprintf("REVOKE GRANT OPTION ON %s.%s FROM %s",
+			database,
+			d.Get("table").(string),
+			userOrRole)
+
+		log.Printf("[DEBUG] SQL: %s", sql)
+		_, err = db.Exec(sql)
+		if err != nil {
+			return fmt.Errorf("error revoking GRANT (%s): %s", sql, err)
+		}
+	}
+
+	whatToRevoke := fmt.Sprintf("ALL ON %s.%s", database, d.Get("table").(string))
+	if len(roles.List()) > 0 {
+		whatToRevoke = flattenList(roles.List(), "'%s'")
+	}
+
+	sql = fmt.Sprintf("REVOKE %s FROM %s", whatToRevoke, userOrRole)
+	log.Printf("[DEBUG] SQL: %s", sql)
+	_, err = db.Exec(sql)
+	if err != nil {
+		return fmt.Errorf("error revoking ALL (%s): %s", sql, err)
 	}
 
 	return nil

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -132,31 +132,39 @@ func testAccGrantCheckDestroy(s *terraform.State) error {
 
 const testAccGrantConfig_basic = `
 resource "mysql_user" "test" {
-        user = "jdoe"
-				host = "example.com"
-				password = "password"
+  user     = "jdoe"
+  host     = "example.com"
+  password = "password"
+}
+
+resource "mysql_database" "test" {
+  name = "foo"
 }
 
 resource "mysql_grant" "test" {
-        user = "${mysql_user.test.user}"
-        host = "${mysql_user.test.host}"
-        database = "foo"
-        privileges = ["UPDATE", "SELECT"]
+  user       = "${mysql_user.test.user}"
+  host       = "${mysql_user.test.host}"
+  database   = "foo"
+  privileges = ["UPDATE", "SELECT"]
 }
 `
 
 const testAccGrantConfig_ssl = `
 resource "mysql_user" "test" {
-        user = "jdoe"
-				host = "example.com"
-				password = "password"
+  user     = "jdoe"
+  host     = "example.com"
+  password = "password"
+}
+
+resource "mysql_database" "test" {
+  name = "foo"
 }
 
 resource "mysql_grant" "test" {
-        user = "${mysql_user.test.user}"
-        host = "${mysql_user.test.host}"
-        database = "foo"
-		privileges = ["UPDATE", "SELECT"]
-		tls_option = "SSL"
+  user       = "${mysql_user.test.user}"
+  host       = "${mysql_user.test.host}"
+  database   = "foo"
+  privileges = ["UPDATE", "SELECT"]
+  tls_option = "SSL"
 }
 `

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -68,8 +68,7 @@ func TestAccGrant_role(t *testing.T) {
 			{
 				Config: testAccGrantConfig_role,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("mysql_grant.developer", "role", "developer"),
-					resource.TestCheckResourceAttr("mysql_grant.test", "database", "foo"),
+					resource.TestCheckResourceAttr("mysql_grant.test", "role", "developer"),
 				),
 			},
 		},
@@ -103,7 +102,6 @@ func TestAccGrant_roleToUser(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("mysql_grant.test", "user", "jdoe"),
 					resource.TestCheckResourceAttr("mysql_grant.test", "host", "example.com"),
-					resource.TestCheckResourceAttr("mysql_grant.test", "database", "foo"),
 					resource.TestCheckResourceAttr("mysql_grant.test", "roles.#", "1"),
 					resource.TestCheckResourceAttr("mysql_grant.test", "roles.0", "developer"),
 				),
@@ -246,7 +244,7 @@ resource "mysql_role" "developer" {
   name = "developer"
 }
 
-resource "mysql_grant" "developer" {
+resource "mysql_grant" "test" {
   role       = "${mysql_role.developer.name}"
   database   = "${mysql_database.test.name}"
   privileges = ["SELECT", "UPDATE"]
@@ -267,7 +265,7 @@ resource "mysql_role" "developer" {
   name = "developer"
 }
 
-resource "mysql_grant" "developer" {
+resource "mysql_grant" "test" {
   user     = "${mysql_user.jdoe.user}"
   host     = "${mysql_user.jdoe.host}"
   roles    = ["${mysql_role.developer.name}"]

--- a/mysql/resource_role.go
+++ b/mysql/resource_role.go
@@ -1,0 +1,83 @@
+package mysql
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceRole() *schema.Resource {
+	return &schema.Resource{
+		Create: CreateRole,
+		Read:   ReadRole,
+		Delete: DeleteRole,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func CreateRole(d *schema.ResourceData, meta interface{}) error {
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
+
+	roleName := d.Get("name").(string)
+
+	sql := fmt.Sprintf("CREATE ROLE '%s'", roleName)
+	log.Printf("[DEBUG] SQL: %s", sql)
+
+	_, err = db.Exec(sql)
+	if err != nil {
+		return fmt.Errorf("error creating role: %s", err)
+	}
+
+	d.SetId(roleName)
+
+	return nil
+}
+
+func ReadRole(d *schema.ResourceData, meta interface{}) error {
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
+
+	sql := fmt.Sprintf("SHOW GRANTS FOR '%s'", d.Id())
+	log.Printf("[DEBUG] SQL: %s", sql)
+
+	_, err = db.Exec(sql)
+	if err != nil {
+		log.Printf("[WARN] Role (%s) not found; removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", d.Id())
+
+	return nil
+}
+
+func DeleteRole(d *schema.ResourceData, meta interface{}) error {
+	db, err := connectToMySQL(meta.(*MySQLConfiguration).Config)
+	if err != nil {
+		return err
+	}
+
+	sql := fmt.Sprintf("DROP ROLE '%s'", d.Get("name").(string))
+	log.Printf("[DEBUG] SQL: %s", sql)
+
+	_, err = db.Exec(sql)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/mysql/resource_role_test.go
+++ b/mysql/resource_role_test.go
@@ -1,0 +1,108 @@
+package mysql
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccRole_basic(t *testing.T) {
+	roleName := "tf-test-role"
+	resourceName := "mysql_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+			if err != nil {
+				return
+			}
+
+			requiredVersion, _ := version.NewVersion("8.0.0")
+			currentVersion, err := serverVersion(db)
+			if err != nil {
+				return
+			}
+
+			if currentVersion.LessThan(requiredVersion) {
+				t.Skip("Roles require MySQL 8+")
+			}
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccRoleCheckDestroy(roleName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleConfig_basic(roleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccRoleExists(roleName),
+					resource.TestCheckResourceAttr(resourceName, "name", roleName),
+				),
+			},
+		},
+	})
+}
+
+func testAccRoleExists(roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+		if err != nil {
+			return err
+		}
+
+		count, err := testAccGetRoleGrantCount(roleName, db)
+
+		if err != nil {
+			return err
+		}
+
+		if count > 0 {
+			return nil
+		}
+
+		return fmt.Errorf("No grants found for role %s", roleName)
+	}
+}
+
+func testAccGetRoleGrantCount(roleName string, db *sql.DB) (int, error) {
+	rows, err := db.Query(fmt.Sprintf("SHOW GRANTS FOR '%s'", roleName))
+	if err != nil {
+		return 0, err
+	}
+
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+	}
+
+	return count, nil
+}
+
+func testAccRoleCheckDestroy(roleName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		db, err := connectToMySQL(testAccProvider.Meta().(*MySQLConfiguration).Config)
+		if err != nil {
+			return err
+		}
+
+		count, err := testAccGetRoleGrantCount(roleName, db)
+		if count > 0 {
+			return fmt.Errorf("Role %s still has grants/exists", roleName)
+		}
+
+		return nil
+	}
+}
+
+func testAccRoleConfig_basic(roleName string) string {
+	return fmt.Sprintf(`
+resource "mysql_role" "test" {
+  name = "%s"
+}
+`, roleName)
+}

--- a/website/docs/r/grant.html.markdown
+++ b/website/docs/r/grant.html.markdown
@@ -63,13 +63,11 @@ resource "mysql_grant" "developer" {
 }
 ```
 
-<<<<<<< HEAD
 ## Argument Reference
 
 ~> **Note:** MySQL removed the `REQUIRE` option from `GRANT` in version 8. `tls_option` is ignored in MySQL 8 and above.
 
 ~> **Note:** Attributes `role` and `roles` are only supported in MySQL 8 and above.
-
 
 The following arguments are supported:
 
@@ -80,13 +78,6 @@ The following arguments are supported:
 * `table` - (Optional) Which table to grant `privileges` on. Defaults to `*`, which is all tables.
 * `privileges` - (Optional) A list of privileges to grant to the user. Refer to a list of privileges (such as [here](https://dev.mysql.com/doc/refman/5.5/en/grant.html)) for applicable privileges. Conflicts with `roles`.
 * `roles` - (Optional) A list of rols to grant to the user. Conflicts with `privileges`.
-=======
-* `user` - (Required) The name of the user.
-* `host` - (Optional) The source host of the user. Defaults to "localhost".
-* `database` - (Required) The database to grant privileges on.
-* `table` - (Optional) Which table to grant `privileges` on. Defaults to `*`, which is all tables.
-* `privileges` - (Required) A list of privileges to grant to the user. Refer to a list of privileges (such as [here](https://dev.mysql.com/doc/refman/5.5/en/grant.html)) for applicable privileges.
->>>>>>> master
 * `tls_option` - (Optional) An TLS-Option for the `GRANT` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `GRANT ... REQUIRE SSL` statement. See the [MYSQL `GRANT` documentation](https://dev.mysql.com/doc/refman/5.7/en/grant.html) for more. Ignored if MySQL version is under 5.7.0.
 * `grant` - (Optional) Whether to also give the user privileges to grant the same privileges to other users.
 

--- a/website/docs/r/grant.html.markdown
+++ b/website/docs/r/grant.html.markdown
@@ -11,7 +11,7 @@ description: |-
 The ``mysql_grant`` resource creates and manages privileges given to
 a user on a MySQL server.
 
-## Example Usage
+## Granting Privileges to a User
 
 ```hcl
 resource "mysql_user" "jdoe" {
@@ -28,15 +28,65 @@ resource "mysql_grant" "jdoe" {
 }
 ```
 
+## Granting Privileges to a Role
+
+```hcl
+resource "mysql_role" "developer" {
+  name = "developer"
+}
+
+resource "mysql_grant" "developer" {
+  role       = "${mysql_role.developer.name}"
+  database   = "app"
+  privileges = ["SELECT", "UPDATE"]
+}
+```
+
+## Adding a Role to a User
+
+```hcl
+resource "mysql_user" "jdoe" {
+  user     = "jdoe"
+  host     = "example.com"
+  password = "password"
+}
+
+resource "mysql_role" "developer" {
+  name = "developer"
+}
+
+resource "mysql_grant" "developer" {
+  user     = "${mysql_user.jdoe.user}"
+  host     = "${mysql_user.jdoe.host}"
+  database = "app"
+  roles    = ["${mysql_role.developer.name}"]
+}
+```
+
+<<<<<<< HEAD
 ## Argument Reference
+
+~> **Note:** MySQL removed the `REQUIRE` option from `GRANT` in version 8. `tls_option` is ignored in MySQL 8 and above.
+
+~> **Note:** Attributes `role` and `roles` are only supported in MySQL 8 and above.
+
 
 The following arguments are supported:
 
+* `user` - (Optional) The name of the user. Conflicts with `role`.
+* `host` - (Optional) The source host of the user. Defaults to "localhost". Conflicts with `role`.
+* `role` - (Optional) The role to grant `privileges` to. Conflicts with `user` and `host`.
+* `database` - (Required) The database to grant privileges on.
+* `table` - (Optional) Which table to grant `privileges` on. Defaults to `*`, which is all tables.
+* `privileges` - (Optional) A list of privileges to grant to the user. Refer to a list of privileges (such as [here](https://dev.mysql.com/doc/refman/5.5/en/grant.html)) for applicable privileges. Conflicts with `roles`.
+* `roles` - (Optional) A list of rols to grant to the user. Conflicts with `privileges`.
+=======
 * `user` - (Required) The name of the user.
 * `host` - (Optional) The source host of the user. Defaults to "localhost".
 * `database` - (Required) The database to grant privileges on.
 * `table` - (Optional) Which table to grant `privileges` on. Defaults to `*`, which is all tables.
 * `privileges` - (Required) A list of privileges to grant to the user. Refer to a list of privileges (such as [here](https://dev.mysql.com/doc/refman/5.5/en/grant.html)) for applicable privileges.
+>>>>>>> master
 * `tls_option` - (Optional) An TLS-Option for the `GRANT` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `GRANT ... REQUIRE SSL` statement. See the [MYSQL `GRANT` documentation](https://dev.mysql.com/doc/refman/5.7/en/grant.html) for more. Ignored if MySQL version is under 5.7.0.
 * `grant` - (Optional) Whether to also give the user privileges to grant the same privileges to other users.
 

--- a/website/docs/r/role.html.markdown
+++ b/website/docs/r/role.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "mysql"
+page_title: "MySQL: mysql_role"
+sidebar_current: "docs-mysql-resource-role"
+description: |-
+  Creates and manages a role  on a MySQL server.
+---
+
+# mysql\_role
+
+The ``mysql_role`` resource creates and manages a user on a MySQL
+server.
+
+~> **Note:** MySQL introduced roles in version 8. They do not work on MySQL 5 and lower.
+
+## Example Usage
+
+```hcl
+resource "mysql_role" "developer" {
+  name = "developer"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the role.
+
+## Attributes Reference
+
+No further attributes are exported.


### PR DESCRIPTION
## What does this PR change?

* Adds a `mysql_role` resource that maps to `CREATE ROLE`. Fixes #46.
* Fixes the provider to work with MySQL 8.0.
* Introduces parallel Travis-CI tests that run tests against MySQL 8.0, 5.7, and 5.6.
* Adds `role` and `roles` arguments to `mysql_grant` to manage permissions on roles and to assign roles to users. Only works with MySQL 8+.

## Proposed HCL

```hcl
resource "mysql_role" "developer" {
  name = "developer"
}

resource "mysql_grant" "developer" {
  role       = "${mysql_role.developer.name}"
  database   = "${mysql_database.test.name}"
  privileges = ["SELECT", "UPDATE"]
}

resource "mysql_user" "jdoe" {
  user     = "jdoe"
  host     = "example.com"
}

resource "mysql_grant" "test" {
  user     = "${mysql_user.jdoe.user}"
  host     = "${mysql_user.jdoe.host}"
  database = "${mysql_database.test.name}"
  roles    = ["${mysql_role.developer.name}"]
}
```

## TODO

- [x] Add tests to `mysql_grant` for `role` and `roles` attributes
- [x] Add documentation
- [x] Document that `tls_option` doesn't work for MySQL 8.0