### PR TITLE
tests: Configure provider before running test

### DIFF
--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -52,4 +52,9 @@ func testAccPreCheck(t *testing.T) {
 			t.Fatal("MYSQL_ENDPOINT, MYSQL_USERNAME and optionally MYSQL_PASSWORD must be set for acceptance tests")
 		}
 	}
+
+	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This should prevent crashes when running tests, e.g.

```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccGrant_role
--- FAIL: TestAccGrant_role (0.00s)

------- Stderr: -------
panic: interface conversion: interface {} is nil, not *mysql.MySQLConfiguration [recovered]
	panic: interface conversion: interface {} is nil, not *mysql.MySQLConfiguration

goroutine 20 [running]:
testing.tRunner.func1(0xc0000fa300)
	/opt/goenv/versions/1.11.5/src/testing/testing.go:792 +0x387
panic(0xcf3c00, 0xc000239140)
	/opt/goenv/versions/1.11.5/src/runtime/panic.go:513 +0x1b9
github.com/terraform-providers/terraform-provider-mysql/mysql.TestAccGrant_role.func1()
	/opt/teamcity-agent/work/1b7580c8394c8d88/src/github.com/terraform-providers/terraform-provider-mysql/mysql/resource_grant_test.go:56 +0x155
github.com/terraform-providers/terraform-provider-mysql/vendor/github.com/hashicorp/terraform/helper/resource.Test(0xf5b500, 0xc0000fa300, 0x0, 0xc000267880, 0xc000238fc0, 0x0, 0x0, 0xe1e248, 0xc0000fc300, 0x1, ...)
	/opt/teamcity-agent/work/1b7580c8394c8d88/src/github.com/terraform-providers/terraform-provider-mysql/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:467 +0x14b2
github.com/terraform-providers/terraform-provider-mysql/mysql.TestAccGrant_role(0xc0000fa300)
	/opt/teamcity-agent/work/1b7580c8394c8d88/src/github.com/terraform-providers/terraform-provider-mysql/mysql/resource_grant_test.go:53 +0x3d7
testing.tRunner(0xc0000fa300, 0xe1e1e0)
	/opt/goenv/versions/1.11.5/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/opt/goenv/versions/1.11.5/src/testing/testing.go:878 +0x35c
```