### PR TITLE
resource_grant: Handle revoke of grants properly

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -275,6 +275,7 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	roles := d.Get("roles").(*schema.Set)
+	privileges := d.Get("privileges").(*schema.Set)
 
 	var sql string
 	if !isRole && len(roles.List()) == 0 {
@@ -293,6 +294,9 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	whatToRevoke := fmt.Sprintf("ALL ON %s.%s", database, table)
 	if len(roles.List()) > 0 {
 		whatToRevoke = flattenList(roles.List(), "'%s'")
+	} else if len(privileges.List()) > 0 {
+		privilegeList = flattenList(privileges.List(), "'%s'")
+		whatToRevoke = fmt.Sprintf("%s ON %s.%s", privilegeList, database, table)
 	}
 
 	sql = fmt.Sprintf("REVOKE %s FROM %s", whatToRevoke, userOrRole)

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -295,7 +295,7 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	if len(roles.List()) > 0 {
 		whatToRevoke = flattenList(roles.List(), "'%s'")
 	} else if len(privileges.List()) > 0 {
-		privilegeList := strings.Join(privileges.List(), ", ")
+		privilegeList := flattenList(privileges.List(), "%s")
 		whatToRevoke = fmt.Sprintf("%s ON %s.%s", privilegeList, database, table)
 	}
 

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -295,7 +295,7 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	if len(roles.List()) > 0 {
 		whatToRevoke = flattenList(roles.List(), "'%s'")
 	} else if len(privileges.List()) > 0 {
-		privilegeList := flattenList(privileges.List(), "'%s'")
+		privilegeList := strings.Join(privileges.List(), ", ")
 		whatToRevoke = fmt.Sprintf("%s ON %s.%s", privilegeList, database, table)
 	}
 

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -295,7 +295,7 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	if len(roles.List()) > 0 {
 		whatToRevoke = flattenList(roles.List(), "'%s'")
 	} else if len(privileges.List()) > 0 {
-		privilegeList = flattenList(privileges.List(), "'%s'")
+		privilegeList := flattenList(privileges.List(), "'%s'")
 		whatToRevoke = fmt.Sprintf("%s ON %s.%s", privilegeList, database, table)
 	}
 


### PR DESCRIPTION
Revoke ALL has the following issues:

- Interferes with other `resource "mysql_grant"` declarations on the same database (or host i.e. `*`)

- Does not work with AWS RDS or Aurora as `REVOKE ALL ON *.* FROM 'user'@'host'` is not allowed.

Revoke explicit list instead.