### PR TITLE
Add compatibility to create databases on mariadb instances

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -119,6 +119,16 @@ func serverVersion(db *sql.DB) (*version.Version, error) {
 	return version.NewVersion(versionString)
 }
 
+func serverVersionString(db *sql.DB) (string, error) {
+	var versionString string
+	err := db.QueryRow("SELECT @@GLOBAL.version").Scan(&versionString)
+	if err != nil {
+		return "", err
+	}
+
+	return versionString, nil
+}
+
 func connectToMySQL(conf *mysql.Config) (*sql.DB, error) {
 	dsn := conf.FormatDSN()
 	var db *sql.DB

--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -125,9 +125,14 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 
+		serverVersionString, err := serverVersionString(db)
+		if err != nil {
+			return err
+		}
+
 		// MySQL 8 returns more data in a row.
 		var res error
-		if currentVersion.GreaterThan(requiredVersion) {
+		if !strings.Contains(serverVersionString, "MariaDB") && currentVersion.GreaterThan(requiredVersion) {
 			res = db.QueryRow(stmtSQL, defaultCharset).Scan(&defaultCollation, &empty, &empty, &empty, &empty, &empty, &empty)
 		} else {
 			res = db.QueryRow(stmtSQL, defaultCharset).Scan(&defaultCollation, &empty, &empty, &empty, &empty, &empty)


### PR DESCRIPTION
This Pull Request fixes #56. It adds an extra check on the version string to separate between MariaDB (version 10.X) and MySql (version 8.X).