### PR TITLE
Update user argument on grant docs

### DIFF
--- a/website/docs/r/grant.html.markdown
+++ b/website/docs/r/grant.html.markdown
@@ -15,9 +15,9 @@ a user on a MySQL server.
 
 ```hcl
 resource "mysql_user" "jdoe" {
-  user     = "jdoe"
-  host     = "example.com"
-  password = "password"
+  user               = "jdoe"
+  host               = "example.com"
+  plaintext_password = "password"
 }
 
 resource "mysql_grant" "jdoe" {
@@ -46,9 +46,9 @@ resource "mysql_grant" "developer" {
 
 ```hcl
 resource "mysql_user" "jdoe" {
-  user     = "jdoe"
-  host     = "example.com"
-  password = "password"
+  user               = "jdoe"
+  host               = "example.com"
+  plaintext_password = "password"
 }
 
 resource "mysql_role" "developer" {


### PR DESCRIPTION
Replaces the deprecated `password` argument with `plaintext_password` for `mysql_user` on `mysql_grant` docs.