### PR TITLE
GH-90 Disable REQUIRE syntax when tls_options=""

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -193,7 +193,7 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 		userOrRole)
 
 	// MySQL 8+ doesn't allow REQUIRE on a GRANT statement.
-	if !hasRoles {
+	if !hasRoles && d.Get("tls_option").(string) != "" {
 		stmtSQL += fmt.Sprintf(" REQUIRE %s", d.Get("tls_option").(string))
 	}
 

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -111,7 +111,7 @@ func CreateUser(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	if currentVersion.GreaterThan(requiredVersion) {
+	if currentVersion.GreaterThan(requiredVersion) && d.Get("tls_option").(string) != "" {
 		stmtSQL += fmt.Sprintf(" REQUIRE %s", d.Get("tls_option").(string))
 	}
 


### PR DESCRIPTION
The REQUIRE NONE / REQUIRE SSL syntax isn't supported by TiDB. Rather
than special case this database, allow the user to disable this syntax
themselves by simply setting `tls_options` to a blank string.

Fixes #90

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>