### PR TITLE
Extend mysql DSN connection parameters

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -84,3 +84,4 @@ The following arguments are supported:
 * `max_conn_lifetime_sec` - (Optional) Sets the maximum amount of time a connection may be reused. If d <= 0, connections are reused forever.
 * `max_open_conns` - (Optional) Sets the maximum number of open connections to the database. If n <= 0, then there is no limit on the number of open connections.
 * `authentication_plugin` - (Optional) Sets the authentication plugin, it can be one of the following: `native` or `cleartext`. Defaults to `native`.
+* `conn_params` - (Optional) Configure mysql DSN parameters. Default value `nil`.


### PR DESCRIPTION
New optional parameter for configuring mysql DSN connection
- conn_params (map) - allow configure mysql connection parameters