### PR TITLE
Add "mysql_tables" data source

### DIFF
--- a/mysql/data_source_tables.go
+++ b/mysql/data_source_tables.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -74,7 +75,7 @@ func ShowTables(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(database)
+	d.SetId(resource.UniqueId())
 
 	return nil
 }

--- a/mysql/data_source_tables.go
+++ b/mysql/data_source_tables.go
@@ -1,0 +1,80 @@
+package mysql
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceTables() *schema.Resource {
+	return &schema.Resource{
+		Read: ShowTables,
+		Schema: map[string]*schema.Schema{
+			"database": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"pattern": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func ShowTables(d *schema.ResourceData, meta interface{}) error {
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
+
+	database := d.Get("database").(string)
+	pattern := d.Get("pattern").(string)
+
+	sql := fmt.Sprintf("SHOW TABLES FROM %s", quoteIdentifier(database))
+
+	if pattern != "" {
+		sql += fmt.Sprintf(" LIKE '%s'", pattern)
+	}
+
+	log.Printf("[DEBUG] SQL: %s", sql)
+
+	rows, err := db.Query(sql)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	var tables []string
+
+	for rows.Next() {
+		var table string
+
+		err := rows.Scan(&table)
+
+		if err != nil {
+			return err
+		}
+
+		tables = append(tables, table)
+	}
+
+	err = d.Set("tables", tables)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(database)
+
+	return nil
+}

--- a/mysql/data_source_tables_test.go
+++ b/mysql/data_source_tables_test.go
@@ -1,0 +1,79 @@
+package mysql
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourceTables(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTablesConfig_basic("mysql", "%"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "database", "mysql"),
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "pattern", "%"),
+					testAccTablesCount("data.mysql_tables.test", "tables.#", func(rn string, table_count int) error {
+						if table_count < 1 {
+							return fmt.Errorf("%s: tables not found", rn)
+						}
+
+						return nil
+					}),
+				),
+			},
+			{
+				Config: testAccTablesConfig_basic("mysql", "__table_does_not_exist__"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "database", "mysql"),
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "pattern", "__table_does_not_exist__"),
+					testAccTablesCount("data.mysql_tables.test", "tables.#", func(rn string, table_count int) error {
+						if table_count > 0 {
+							return fmt.Errorf("%s: unexpected table found", rn)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccTablesCount(rn string, key string, check func(string, int) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		value, ok := rs.Primary.Attributes[key]
+
+		if !ok {
+			return fmt.Errorf("%s: attribute '%s' not found", rn, key)
+		}
+
+		table_count, err := strconv.Atoi(value)
+
+		if err != nil {
+			return err
+		}
+
+		return check(rn, table_count)
+	}
+}
+
+func testAccTablesConfig_basic(database string, pattern string) string {
+	return fmt.Sprintf(`
+data "mysql_tables" "test" {
+		database = "%s"
+		pattern = "%s"
+}`, database, pattern)
+}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -99,6 +99,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"mysql_tables": dataSourceTables(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"mysql_database":      resourceDatabase(),
 			"mysql_grant":         resourceGrant(),


### PR DESCRIPTION
Add a data source that reads MySQL tables dynamically:

```terraform
data "mysql_tables" "employee_prefix_tables" {
  database = "employees"
  pattern  = "employee%"
}

output "employee_prefix_tables" {
  value = data.mysql_tables.employee_prefix_tables.tables #=> ["employees", "employee_titles", ...]
}

// use case example
resource "mysql_grant" "jdoe" {
  for_each   = toset(data.mysql_tables.employee_prefix_tables.tables)
  user       = "jdoe"
  host       = "%"
  database   = "employees"
  table      = each.key
  privileges = ["SELECT", "UPDATE"]
}
```
