### PR TITLE
Update logic in resource_user_password

### DIFF
--- a/mysql/resource_user_password.go
+++ b/mysql/resource_user_password.go
@@ -70,6 +70,9 @@ func SetUserPassword(d *schema.ResourceData, meta interface{}) error {
 
 	/* ALTER USER syntax introduced in MySQL 5.7.6 deprecates SET PASSWORD (GH-8230) */
 	serverVersion, err := serverVersion(db)
+	if err != nil {
+		return fmt.Errorf("Could not determine server version: %s", err)
+	}
 	ver, _ := version.NewVersion("5.7.6")
 	var stmtSQL string
 	if serverVersion.LessThan(ver) {


### PR DESCRIPTION
This PR updates `resource_user_password` to use the same logic as `resource_user` to set and update a user's password.

For MySQL versions up to 5.7.6, it will use `SET PASSWORD` and for later versions, it will use `ALTER USER` 
