### PR TITLE
Support update grant

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,7 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4/go.mod h1:JDmizlhaP5P0rYTTZB0reDMefAiJyfWPEtugV4in1oI=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0 h1:3AjuuV1LJKs1NlG+heUgqWN6/QCSx2kDhyS6K7F0fTw=
 github.com/hashicorp/terraform-plugin-sdk v1.0.0/go.mod h1:NuwtLpEpPsFaKJPJNGtMcn9vlhe6Ofe+Y6NqXhJgV2M=
+github.com/hashicorp/terraform-plugin-sdk v1.9.1 h1:AgHnd6yPCg7o57XWrv4L7tIMdF0KQpcZro1pDHF1Xbw=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=

--- a/mysql/data_source_tables.go
+++ b/mysql/data_source_tables.go
@@ -1,0 +1,81 @@
+package mysql
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceTables() *schema.Resource {
+	return &schema.Resource{
+		Read: ShowTables,
+		Schema: map[string]*schema.Schema{
+			"database": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"pattern": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tables": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func ShowTables(d *schema.ResourceData, meta interface{}) error {
+	db, err := connectToMySQL(meta.(*MySQLConfiguration))
+
+	if err != nil {
+		return err
+	}
+
+	database := d.Get("database").(string)
+	pattern := d.Get("pattern").(string)
+
+	sql := fmt.Sprintf("SHOW TABLES FROM %s", quoteIdentifier(database))
+
+	if pattern != "" {
+		sql += fmt.Sprintf(" LIKE '%s'", pattern)
+	}
+
+	log.Printf("[DEBUG] SQL: %s", sql)
+
+	rows, err := db.Query(sql)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	var tables []string
+
+	for rows.Next() {
+		var table string
+
+		err := rows.Scan(&table)
+
+		if err != nil {
+			return err
+		}
+
+		tables = append(tables, table)
+	}
+
+	err = d.Set("tables", tables)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(resource.UniqueId())
+
+	return nil
+}

--- a/mysql/data_source_tables.go
+++ b/mysql/data_source_tables.go
@@ -30,11 +30,7 @@ func dataSourceTables() *schema.Resource {
 }
 
 func ShowTables(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	database := d.Get("database").(string)
 	pattern := d.Get("pattern").(string)

--- a/mysql/data_source_tables_test.go
+++ b/mysql/data_source_tables_test.go
@@ -1,0 +1,79 @@
+package mysql
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourceTables(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTablesConfig_basic("mysql", "%"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "database", "mysql"),
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "pattern", "%"),
+					testAccTablesCount("data.mysql_tables.test", "tables.#", func(rn string, table_count int) error {
+						if table_count < 1 {
+							return fmt.Errorf("%s: tables not found", rn)
+						}
+
+						return nil
+					}),
+				),
+			},
+			{
+				Config: testAccTablesConfig_basic("mysql", "__table_does_not_exist__"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "database", "mysql"),
+					resource.TestCheckResourceAttr("data.mysql_tables.test", "pattern", "__table_does_not_exist__"),
+					testAccTablesCount("data.mysql_tables.test", "tables.#", func(rn string, table_count int) error {
+						if table_count > 0 {
+							return fmt.Errorf("%s: unexpected table found", rn)
+						}
+
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccTablesCount(rn string, key string, check func(string, int) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		value, ok := rs.Primary.Attributes[key]
+
+		if !ok {
+			return fmt.Errorf("%s: attribute '%s' not found", rn, key)
+		}
+
+		table_count, err := strconv.Atoi(value)
+
+		if err != nil {
+			return err
+		}
+
+		return check(rn, table_count)
+	}
+}
+
+func testAccTablesConfig_basic(database string, pattern string) string {
+	return fmt.Sprintf(`
+data "mysql_tables" "test" {
+		database = "%s"
+		pattern = "%s"
+}`, database, pattern)
+}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -169,7 +169,7 @@ func makeDialer(d *schema.ResourceData) (proxy.Dialer, error) {
 		if err != nil {
 			return nil, err
 		}
-		proxy, err := proxy.FromURL(proxyURL, proxyFromEnv)
+		proxy, err := proxy.FromURL(proxyURL, proxy.Direct)
 		if err != nil {
 			return nil, err
 		}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -27,6 +27,7 @@ const (
 
 type MySQLConfiguration struct {
 	Config                 *mysql.Config
+	Db                     *sql.DB
 	MaxConnLifetime        time.Duration
 	MaxOpenConns           int
 	ConnectRetryTimeoutSec time.Duration
@@ -150,12 +151,22 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return dialer.Dial("tcp", network)
 	})
 
-	return &MySQLConfiguration{
+	mysqlConf := &MySQLConfiguration{
 		Config:                 &conf,
 		MaxConnLifetime:        time.Duration(d.Get("max_conn_lifetime_sec").(int)) * time.Second,
 		MaxOpenConns:           d.Get("max_open_conns").(int),
 		ConnectRetryTimeoutSec: time.Duration(d.Get("connect_retry_timeout_sec").(int)) * time.Second,
-	}, nil
+	}
+
+	db, err := connectToMySQL(mysqlConf)
+
+	if err != nil {
+		return nil, err
+	}
+
+	mysqlConf.Db = db
+
+	return mysqlConf, nil
 }
 
 var identQuoteReplacer = strings.NewReplacer("`", "``")

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -106,6 +106,10 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"mysql_tables": dataSourceTables(),
+		},
+
 		ResourcesMap: map[string]*schema.Resource{
 			"mysql_database":      resourceDatabase(),
 			"mysql_grant":         resourceGrant(),

--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -47,15 +47,12 @@ func resourceDatabase() *schema.Resource {
 }
 
 func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	stmtSQL := databaseConfigSQL("CREATE", d)
 	log.Println("Executing statement:", stmtSQL)
 
-	_, err = db.Exec(stmtSQL)
+	_, err := db.Exec(stmtSQL)
 	if err != nil {
 		return err
 	}
@@ -66,15 +63,12 @@ func CreateDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	stmtSQL := databaseConfigSQL("ALTER", d)
 	log.Println("Executing statement:", stmtSQL)
 
-	_, err = db.Exec(stmtSQL)
+	_, err := db.Exec(stmtSQL)
 	if err != nil {
 		return err
 	}
@@ -83,10 +77,7 @@ func UpdateDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	// This is kinda flimsy-feeling, since it depends on the formatting
 	// of the SHOW CREATE DATABASE output... but this data doesn't seem
@@ -98,7 +89,7 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 
 	log.Println("Executing query:", stmtSQL)
 	var createSQL, _database string
-	err = db.QueryRow(stmtSQL).Scan(&_database, &createSQL)
+	err := db.QueryRow(stmtSQL).Scan(&_database, &createSQL)
 	if err != nil {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 			if mysqlErr.Number == unknownDatabaseErrCode {
@@ -155,16 +146,13 @@ func ReadDatabase(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteDatabase(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	name := d.Id()
 	stmtSQL := "DROP DATABASE " + quoteIdentifier(name)
 	log.Println("Executing statement:", stmtSQL)
 
-	_, err = db.Exec(stmtSQL)
+	_, err := db.Exec(stmtSQL)
 	if err == nil {
 		d.SetId("")
 	}

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -23,7 +23,7 @@ type MySQLGrant struct {
 func resourceGrant() *schema.Resource {
 	return &schema.Resource{
 		Create: CreateGrant,
-		Update: nil,
+		Update: UpdateGrant,
 		Read:   ReadGrant,
 		Delete: DeleteGrant,
 		Importer: &schema.ResourceImporter{
@@ -69,7 +69,6 @@ func resourceGrant() *schema.Resource {
 			"privileges": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -268,6 +267,16 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("privileges", privileges)
 	d.Set("grant", grantOption)
+
+	return nil
+}
+
+func UpdateGrant(d *schema.ResourceData, meta interface{}) error {
+	if d.HasChange("privileges") {
+		oldPrivs, newPrivs := d.GetChange("plaintext_password")
+		log.Printf("xxx old: %v\n", oldPrivs)
+		log.Printf("xxx new: %v\n", newPrivs)
+	}
 
 	return nil
 }

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -143,10 +143,7 @@ func supportsRoles(db *sql.DB) (bool, error) {
 }
 
 func CreateGrant(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	hasRoles, err := supportsRoles(db)
 	if err != nil {
@@ -222,10 +219,7 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadGrant(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	hasRoles, err := supportsRoles(db)
 	if err != nil {
@@ -255,10 +249,7 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	database := formatDatabaseName(d.Get("database").(string))
 
@@ -323,11 +314,7 @@ func ImportGrant(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceDa
 	user := userHost[0]
 	host := userHost[1]
 
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-
-	if err != nil {
-		return nil, err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	sql := fmt.Sprintf("SHOW GRANTS FOR '%s'@'%s'", user, host)
 	rows, err := db.Query(sql)

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -374,6 +374,7 @@ func restoreGrant(user string, host string, database string, table string, privs
 	d.Set("host", host)
 	d.Set("database", database)
 	d.Set("table", table)
+	d.Set("tls_option", "NONE")
 
 	priv_list := strings.Split(privsStr, ",")
 	privileges := make([]string, len(priv_list))

--- a/mysql/resource_role.go
+++ b/mysql/resource_role.go
@@ -24,17 +24,14 @@ func resourceRole() *schema.Resource {
 }
 
 func CreateRole(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	roleName := d.Get("name").(string)
 
 	sql := fmt.Sprintf("CREATE ROLE '%s'", roleName)
 	log.Printf("[DEBUG] SQL: %s", sql)
 
-	_, err = db.Exec(sql)
+	_, err := db.Exec(sql)
 	if err != nil {
 		return fmt.Errorf("error creating role: %s", err)
 	}
@@ -45,15 +42,12 @@ func CreateRole(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadRole(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	sql := fmt.Sprintf("SHOW GRANTS FOR '%s'", d.Id())
 	log.Printf("[DEBUG] SQL: %s", sql)
 
-	_, err = db.Exec(sql)
+	_, err := db.Exec(sql)
 	if err != nil {
 		log.Printf("[WARN] Role (%s) not found; removing from state", d.Id())
 		d.SetId("")
@@ -66,15 +60,12 @@ func ReadRole(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteRole(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	sql := fmt.Sprintf("DROP ROLE '%s'", d.Get("name").(string))
 	log.Printf("[DEBUG] SQL: %s", sql)
 
-	_, err = db.Exec(sql)
+	_, err := db.Exec(sql)
 	if err != nil {
 		return err
 	}

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -68,10 +68,7 @@ func resourceUser() *schema.Resource {
 }
 
 func CreateUser(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	var authStm string
 	var auth string
@@ -132,10 +129,7 @@ func CreateUser(d *schema.ResourceData, meta interface{}) error {
 }
 
 func UpdateUser(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	var auth string
 	if v, ok := d.GetOk("auth_plugin"); ok {
@@ -210,10 +204,7 @@ func UpdateUser(d *schema.ResourceData, meta interface{}) error {
 }
 
 func ReadUser(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	stmtSQL := fmt.Sprintf("SELECT USER FROM mysql.user WHERE USER='%s'",
 		d.Get("user").(string))
@@ -233,10 +224,7 @@ func ReadUser(d *schema.ResourceData, meta interface{}) error {
 }
 
 func DeleteUser(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	stmtSQL := fmt.Sprintf("DROP USER '%s'@'%s'",
 		d.Get("user").(string),
@@ -244,7 +232,7 @@ func DeleteUser(d *schema.ResourceData, meta interface{}) error {
 
 	log.Println("Executing statement:", stmtSQL)
 
-	_, err = db.Exec(stmtSQL)
+	_, err := db.Exec(stmtSQL)
 	if err == nil {
 		d.SetId("")
 	}
@@ -261,14 +249,10 @@ func ImportUser(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceDat
 	user := userHost[0]
 	host := userHost[1]
 
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-
-	if err != nil {
-		return nil, err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	var count int
-	err = db.QueryRow("SELECT COUNT(1) FROM mysql.user WHERE user = ? AND host = ?", user, host).Scan(&count)
+	err := db.QueryRow("SELECT COUNT(1) FROM mysql.user WHERE user = ? AND host = ?", user, host).Scan(&count)
 
 	if err != nil {
 		return nil, err

--- a/mysql/resource_user_password.go
+++ b/mysql/resource_user_password.go
@@ -44,10 +44,7 @@ func resourceUserPassword() *schema.Resource {
 }
 
 func SetUserPassword(d *schema.ResourceData, meta interface{}) error {
-	db, err := connectToMySQL(meta.(*MySQLConfiguration))
-	if err != nil {
-		return err
-	}
+	db := meta.(*MySQLConfiguration).Db
 
 	uuid, err := uuid.NewV4()
 	if err != nil {


### PR DESCRIPTION
Prevent re-creation when updating privileges

```diff
  # mysql_grant.scott will be updated in-place
  ~ resource "mysql_grant" "scott" {
        database   = "mysql"
        grant      = false
        host       = "localhost"
        id         = "scott@localhost:`mysql`"
      ~ privileges = [
          + "DELETE",
            "INSERT",
            "SELECT",
            "UPDATE",
        ]
        table      = "user"
        tls_option = "NONE"
        user       = "scott"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```