### PR TITLE
Improve Docs: Terraform 0.12 syntax of example

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -52,9 +52,9 @@ resource "aws_db_instance" "default" {
 # Configure the MySQL provider based on the outcome of
 # creating the aws_db_instance.
 provider "mysql" {
-  endpoint = "${aws_db_instance.default.endpoint}"
-  username = "${aws_db_instance.default.username}"
-  password = "${aws_db_instance.default.password}"
+  endpoint = aws_db_instance.default.endpoint
+  username = aws_db_instance.default.username
+  password = aws_db_instance.default.password
 }
 
 # Create a second database, in addition to the "initial_db" created


### PR DESCRIPTION
Hi folks,

that's just a minor change and hopefully in the right place.

I've updated the example to use [First-class expressions](https://www.terraform.io/upgrade-guides/0-12.html#first-class-expressions) from Terraform 0.12.